### PR TITLE
install_fedora: remove trailing spaces

### DIFF
--- a/install_fedora.sh
+++ b/install_fedora.sh
@@ -3,8 +3,8 @@ sudo dnf install -y zsh \
 					vim-X11 \
 					git \
 					terminator \
-					ShellCheck \ 
-					clang-tools-extra \ 
+					ShellCheck \
+					clang-tools-extra \
 					cppcheck \
 					powerline \
 					powerline-fonts


### PR DESCRIPTION
Remove the trailing space to be able to install all the needed packages.